### PR TITLE
Port to 1.21.6-1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,20 +43,17 @@ tasks.register("spotbugs", SpotBugsTask) { task ->
         task.classDirs.from(task.classDirs.files, it.output)
         task.auxClassPaths.from(task.auxClassPaths.files, it.compileClasspath)
     }
-    excludeFilter = file("spotbugs.xml")
+    excludeFilter = rootProject.file("spotbugs.xml")
     ignoreFailures = true
     reports {
-        if (local) {
-            html {
-                required = true
-                outputLocation = file("$buildDir/reports/spotbugs/main/spotbugs.html")
-                stylesheet = 'fancy-hist.xsl'
-            }
-        } else {
-            sarif {
-                required = true
-                outputLocation = file("$buildDir/reports/spotbugs/main/spotbugs.sarif")
-            }
+        html {
+            required = true
+            outputLocation = rootProject.file("${rootProject.buildDir}/reports/spotbugs/main/spotbugs.html")
+            stylesheet = 'fancy-hist.xsl'
+        }
+        sarif {
+            required = true
+            outputLocation = rootProject.file("${rootProject.buildDir}/reports/spotbugs/main/spotbugs.sarif")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
 minecraft_version=[VERSIONED]
-fabric_loader=0.16.10
+fabric_loader=0.16.13
 yarn_mappings=[VERSIONED]
 fabric_api=[VERSIONED]
 midnightlib_version =[VERSIONED]

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 }
 
 plugins {
-    id "dev.kikugie.stonecutter" version "0.6"
+    id "dev.kikugie.stonecutter" version "0.7.6"
 }
 
 stonecutter {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ plugins {
 
 stonecutter {
     create(rootProject) {
-        versions "1.21.1", "1.21.4", "1.21.5", "1.21.6"
+        versions "1.21.1", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8"
         vcsVersion = "1.21.1"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ plugins {
 
 stonecutter {
     create(rootProject) {
-        versions "1.21.1", "1.21.4", "1.21.5"
+        versions "1.21.1", "1.21.4", "1.21.5", "1.21.6"
         vcsVersion = "1.21.1"
     }
 }

--- a/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
@@ -21,6 +21,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+//? if >=1.21.6 {
+/*import net.minecraft.storage.ReadView;
+import net.minecraft.storage.WriteView;
+*///?}
 //? if =1.21.1 {
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
@@ -162,6 +166,7 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Link
         if (!CollisionUtils.shouldCollide(this, entity)) ci.cancel();
     }
 
+    //? if <1.21.6 {
     @Inject(at = @At("RETURN"), method = "writeCustomDataToNbt")
     private void linkart$write(NbtCompound nbt, CallbackInfo ci) {
         if (linkart$followingUUID != null) nbt./*? if >=1.21.5 {*//*put*//*?} else {*/putUuid/*?}*/("LK-Following"/*? if >=1.21.5 {*//*, Uuids.INT_STREAM_CODEC*//*?}*/, linkart$followingUUID);
@@ -181,6 +186,24 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Link
         if (nbt.contains("LK-ItemStack")) linkart$itemStack = ItemStack.fromNbtOrEmpty(this.getRegistryManager(), nbt.getCompound("LK-ItemStack"));
         /*?}*/
     }
+    //?} else {
+    /*@Inject(at = @At("RETURN"), method = "writeCustomData")
+    private void linkart$write(WriteView view, CallbackInfo ci) {
+        view.putNullable("LK-Following", Uuids.INT_STREAM_CODEC, linkart$followingUUID);
+        view.putNullable("LK-Follower", Uuids.INT_STREAM_CODEC, linkart$followerUUID);
+
+        if(!linkart$itemStack.isEmpty()) {
+            view.put("LK-ItemStack", ItemStack.CODEC, linkart$itemStack);
+        }
+    }
+
+    @Inject(at = @At("RETURN"), method = "readCustomData")
+    private void linkart$read(ReadView view, CallbackInfo ci) {
+        view.read("LK-Following", Uuids.INT_STREAM_CODEC).ifPresent(uuid -> linkart$followingUUID = uuid);
+        view.read("LK-Follower", Uuids.INT_STREAM_CODEC).ifPresent(uuid -> linkart$followerUUID = uuid);
+        linkart$itemStack = view.read("Item", ItemStack.CODEC).orElse(ItemStack.EMPTY);
+    }
+    *///?}
 
     @Override
     public AbstractMinecartEntity linkart$getFollowing() {

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,7 +1,2 @@
 plugins.apply "dev.kikugie.stonecutter"
 stonecutter.active "1.21.1" /* [SC] DO NOT EDIT */
-
-stonecutter.registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) { 
-    setGroup "project"
-    ofTask "build"
-}

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -1,0 +1,3 @@
+yarn_mappings=1.21.6+build.1
+fabric_api=0.127.1+1.21.6
+midnightlib_version=1.7.5+1.21.6-fabric

--- a/versions/1.21.7/gradle.properties
+++ b/versions/1.21.7/gradle.properties
@@ -1,0 +1,3 @@
+yarn_mappings=1.21.7+build.8
+fabric_api=0.129.0+1.21.7
+midnightlib_version=1.7.5+1.21.6-fabric

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -1,0 +1,3 @@
+yarn_mappings=1.21.8+build.1
+fabric_api=0.130.0+1.21.8
+midnightlib_version=1.7.5+1.21.6-fabric


### PR DESCRIPTION
More of the same. Had to rewrite `linkart${read,write}` due to the [1.21.6 changes](https://fabricmc.net/2025/06/15/1216.html#nbt) to how NBT is read/written.

Additionally updated to Stonecutter 0.7.6, as it is no longer in beta. Goodbye chiseled tasks, hello easy builds.